### PR TITLE
Transplant .py from Python2.7 to Python3.5

### DIFF
--- a/SMEC_EMC_FIG/SMEC_EMC_FIG.py
+++ b/SMEC_EMC_FIG/SMEC_EMC_FIG.py
@@ -1,10 +1,10 @@
-﻿import Image
+﻿from PIL import Image
 import pickle
 
 RED = (255,0,0,255)
 BLUE = (0,255,255,255)
 
-im = Image.open(r"d:\Workspace\Python27\SMEC_EMC_FIG\TestData\fig1.png")
+im = Image.open(r"E:\Workspace\Python27\SMEC_EMC_FIG\TestData\fig1.png")
 im_data = list(im.getdata())
 width = im.size[0]
 height = im.size[1]


### PR DESCRIPTION
Since pil package is an old version, some guys mantain pil but with a
new name pillow which could be used in Python 3.5, so it's posssible to
use Image Library in Python 3.5.
